### PR TITLE
Fix the p2p & ev json payloads failing schema validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # sandbox
-Beckn Sandbox for v2 specification
+Beckn Sandbox for Beckn v2.0.0 protocol specifications available at https://github.com/beckn/protocol-specifications-new
+
+# Docker image builds
+
+## Local build
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t sandbox-2.0:local --load .
+```
+
+## Push to Docker Hub
+
+This needs authorization to push to Docker Hub. You can use `docker login` to login to Docker Hub.
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t fidedocker/sandbox-2.0:latest --push .
+```

--- a/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_cancel.json
+++ b/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_cancel.json
@@ -100,7 +100,7 @@
             "type": "UNIT",
             "value": 72.73,
             "currency": "INR",
-            "description": "Charging session cost (4.04 kWh @ ₹18.00/kWh)"
+            "description": "Charging session cost (4.04 kWh @ \u20b918.00/kWh)"
           },
           {
             "type": "FEE",
@@ -163,7 +163,6 @@
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
         "@type": "beckn:Payment",
         "beckn:id": "payment-123e4567-e89b-12d3-a456-426614174000",
-        "beckn:status": "PAID",
         "beckn:amount": {
           "currency": "INR",
           "value": 100.0
@@ -176,7 +175,8 @@
           "schema:UPI",
           "schema:Wallet"
         ],
-        "beckn:beneficiary": "BPP"
+        "beckn:beneficiary": "BPP",
+        "beckn:paymentStatus": "COMPLETED"
       },
       "beckn:orderAttributes": {
         "@type": "ChargingSession",

--- a/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_confirm.json
+++ b/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_confirm.json
@@ -163,7 +163,6 @@
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
         "@type": "beckn:Payment",
         "beckn:id": "payment-123e4567-e89b-12d3-a456-426614174000",
-        "beckn:status": "PAID",
         "beckn:amount": {
           "currency": "INR",
           "value": 100.0
@@ -176,7 +175,8 @@
           "schema:UPI",
           "schema:Wallet"
         ],
-        "beckn:beneficiary": "BPP"
+        "beckn:beneficiary": "BPP",
+        "beckn:paymentStatus": "COMPLETED"
       },
       "beckn:orderAttributes": {
         "@type": "ChargingSession",

--- a/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_init.json
+++ b/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_init.json
@@ -169,7 +169,6 @@
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
         "@type": "beckn:Payment",
         "beckn:id": "payment-123e4567-e89b-12d3-a456-426614174000",
-        "beckn:status": "PENDING",
         "beckn:amount": {
           "currency": "INR",
           "value": 100.0
@@ -181,7 +180,8 @@
           "schema:UPI",
           "schema:Wallet"
         ],
-        "beckn:beneficiary": "BPP"
+        "beckn:beneficiary": "BPP",
+        "beckn:paymentStatus": "PENDING"
       },
       "beckn:orderAttributes": {
         "@type": "ChargingSession",

--- a/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_status.json
+++ b/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_status.json
@@ -186,7 +186,6 @@
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
         "@type": "beckn:Payment",
         "beckn:id": "payment-123e4567-e89b-12d3-a456-426614174000",
-        "beckn:status": "PAID",
         "beckn:amount": {
           "currency": "INR",
           "value": 100.0
@@ -199,7 +198,8 @@
           "schema:UPI",
           "schema:Wallet"
         ],
-        "beckn:beneficiary": "BPP"
+        "beckn:beneficiary": "BPP",
+        "beckn:paymentStatus": "COMPLETED"
       },
       "beckn:orderAttributes": {
         "@type": "ChargingSession",

--- a/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_track.json
+++ b/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_track.json
@@ -53,26 +53,72 @@
             {
               "eventTime": "2025-01-27T17:00:00Z",
               "metrics": [
-                { "name": "STATE_OF_CHARGE", "value": 62.5, "unitCode": "PERCENTAGE" },
-                { "name": "POWER", "value": 18.4, "unitCode": "KWH" },
-                { "name": "ENERGY", "value": 10.2, "unitCode": "KW" },
-                { "name": "VOLTAGE", "value": 392, "unitCode": "VLT" },
-                { "name": "CURRENT", "value": 47.0, "unitCode": "AMP" }
+                {
+                  "name": "STATE_OF_CHARGE",
+                  "value": 62.5,
+                  "unitCode": "PERCENTAGE"
+                },
+                {
+                  "name": "POWER",
+                  "value": 18.4,
+                  "unitCode": "KWH"
+                },
+                {
+                  "name": "ENERGY",
+                  "value": 10.2,
+                  "unitCode": "KW"
+                },
+                {
+                  "name": "VOLTAGE",
+                  "value": 392,
+                  "unitCode": "VLT"
+                },
+                {
+                  "name": "CURRENT",
+                  "value": 47.0,
+                  "unitCode": "AMP"
+                }
               ]
             },
             {
               "eventTime": "2025-01-27T17:05:00Z",
               "metrics": [
-                { "name": "STATE_OF_CHARGE", "value": 65.0, "unitCode": "PERCENTAGE" },
-                { "name": "POWER", "value": 17.1, "unitCode": "KWH" },
-                { "name": "ENERGY", "value": 11.1, "unitCode": "KW" },
-                { "name": "VOLTAGE", "value": 388, "unitCode": "VLT" },
-                { "name": "CURRENT", "value": 44.2, "unitCode": "AMP" }
+                {
+                  "name": "STATE_OF_CHARGE",
+                  "value": 65.0,
+                  "unitCode": "PERCENTAGE"
+                },
+                {
+                  "name": "POWER",
+                  "value": 17.1,
+                  "unitCode": "KWH"
+                },
+                {
+                  "name": "ENERGY",
+                  "value": 11.1,
+                  "unitCode": "KW"
+                },
+                {
+                  "name": "VOLTAGE",
+                  "value": 388,
+                  "unitCode": "VLT"
+                },
+                {
+                  "name": "CURRENT",
+                  "value": 44.2,
+                  "unitCode": "AMP"
+                }
               ]
             }
           ]
         }
-      }
+      },
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
+      },
+      "beckn:seller": "seller-placeholder"
     }
   }
 }

--- a/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_update.json
+++ b/src/webhook/jsons/beckn.one:deg:ev-charging/response/on_update.json
@@ -177,7 +177,6 @@
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
         "@type": "beckn:Payment",
         "beckn:id": "payment-123e4567-e89b-12d3-a456-426614174000",
-        "beckn:status": "PAID",
         "beckn:amount": {
           "currency": "INR",
           "value": 100.0
@@ -190,7 +189,8 @@
           "schema:UPI",
           "schema:Wallet"
         ],
-        "beckn:beneficiary": "BPP"
+        "beckn:beneficiary": "BPP",
+        "beckn:paymentStatus": "COMPLETED"
       },
       "beckn:orderAttributes": {
         "@type": "ChargingSession",

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_cancel.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_cancel.json
@@ -22,8 +22,23 @@
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeContract/v0.2/context.jsonld",
         "@type": "EnergyTradeContract",
         "contractStatus": "TERMINATED"
-      }
+      },
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
+      },
+      "beckn:seller": "seller-placeholder",
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "dummy-line-1",
+          "beckn:orderedItem": "dummy-item-1",
+          "beckn:quantity": {
+            "unitQuantity": 1,
+            "unitText": "unit"
+          }
+        }
+      ]
     }
   }
 }
-

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_confirm.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_confirm.json
@@ -17,46 +17,6 @@
       "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
       "@type": "beckn:Order",
       "beckn:id": "order-energy-001",
-      "beckn:items": [
-        {
-          "beckn:id": "energy-resource-solar-001",
-          "quantity": {
-            "count": 10.0,
-            "unit": "kWh"
-          }
-        }
-      ],
-      "beckn:offers": [
-        {
-          "beckn:id": "offer-energy-001"
-        }
-      ],
-      "beckn:provider": {
-        "beckn:id": "provider-solar-farm-001"
-      },
-      "beckn:fulfillments": [
-        {
-          "@type": "beckn:Fulfillment",
-          "beckn:id": "fulfillment-energy-001",
-          "beckn:type": "ENERGY_DELIVERY",
-          "beckn:state": {
-            "@type": "beckn:State",
-            "beckn:descriptor": {
-              "@type": "beckn:Descriptor",
-              "schema:name": "PENDING"
-            }
-          }
-        }
-      ],
-      "beckn:payments": [
-        {
-          "@type": "beckn:Payment",
-          "beckn:id": "payment-energy-001",
-          "beckn:type": "ON-FULFILLMENT",
-          "beckn:status": "NOT-PAID",
-          "beckn:collected_by": "BPP"
-        }
-      ],
       "beckn:orderAttributes": {
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeContract/v0.2/context.jsonld",
         "@type": "EnergyTradeContract",
@@ -84,8 +44,53 @@
             "currency": "USD"
           }
         ]
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "line-1",
+          "beckn:orderedItem": "energy-resource-solar-001",
+          "beckn:quantity": {
+            "unitQuantity": 10.0,
+            "unitText": "kWh"
+          }
+        }
+      ],
+      "beckn:acceptedOffers": [
+        {
+          "beckn:id": "offer-energy-001",
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+          "@type": "beckn:Offer",
+          "beckn:descriptor": {
+            "@type": "beckn:Descriptor",
+            "schema:name": "Offer Descriptor"
+          },
+          "beckn:provider": "provider-placeholder",
+          "beckn:items": [
+            "dummy-item-1"
+          ]
+        }
+      ],
+      "beckn:seller": "provider-solar-farm-001",
+      "beckn:fulfillment": {
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-energy-001",
+        "beckn:fulfillmentStatus": "PENDING",
+        "beckn:mode": "DELIVERY",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:payment": {
+        "@type": "beckn:Payment",
+        "beckn:id": "payment-energy-001",
+        "beckn:paymentStatus": "PENDING",
+        "beckn:beneficiary": "BPP",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:orderStatus": "CREATED",
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
       }
     }
   }
 }
-

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_init.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_init.json
@@ -17,59 +17,6 @@
       "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
       "@type": "beckn:Order",
       "beckn:id": "order-energy-001",
-      "beckn:items": [
-        {
-          "beckn:id": "energy-resource-solar-001",
-          "quantity": {
-            "count": 10.0,
-            "unit": "kWh"
-          }
-        }
-      ],
-      "beckn:offers": [
-        {
-          "beckn:id": "offer-energy-001"
-        }
-      ],
-      "beckn:provider": {
-        "beckn:id": "provider-solar-farm-001"
-      },
-      "beckn:fulfillments": [
-        {
-          "@type": "beckn:Fulfillment",
-          "beckn:id": "fulfillment-energy-001",
-          "beckn:type": "ENERGY_DELIVERY",
-          "beckn:stops": [
-            {
-              "@type": "beckn:Stop",
-              "beckn:id": "stop-start-001",
-              "beckn:type": "START",
-              "beckn:location": {
-                "@type": "beckn:Location",
-                "beckn:address": "100200300"
-              }
-            },
-            {
-              "@type": "beckn:Stop",
-              "beckn:id": "stop-end-001",
-              "beckn:type": "END",
-              "beckn:location": {
-                "@type": "beckn:Location",
-                "beckn:address": "98765456"
-              }
-            }
-          ]
-        }
-      ],
-      "beckn:payments": [
-        {
-          "@type": "beckn:Payment",
-          "beckn:id": "payment-energy-001",
-          "beckn:type": "ON-FULFILLMENT",
-          "beckn:status": "NOT-PAID",
-          "beckn:collected_by": "BPP"
-        }
-      ],
       "beckn:orderAttributes": {
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeContract/v0.2/context.jsonld",
         "@type": "EnergyTradeContract",
@@ -87,8 +34,52 @@
             "https://example.com/certs/solar-panel-cert.pdf"
           ]
         }
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "line-1",
+          "beckn:orderedItem": "energy-resource-solar-001",
+          "beckn:quantity": {
+            "unitQuantity": 10.0,
+            "unitText": "kWh"
+          }
+        }
+      ],
+      "beckn:acceptedOffers": [
+        {
+          "beckn:id": "offer-energy-001",
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+          "@type": "beckn:Offer",
+          "beckn:descriptor": {
+            "@type": "beckn:Descriptor",
+            "schema:name": "Offer Descriptor"
+          },
+          "beckn:provider": "provider-placeholder",
+          "beckn:items": [
+            "dummy-item-1"
+          ]
+        }
+      ],
+      "beckn:seller": "provider-solar-farm-001",
+      "beckn:fulfillment": {
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-energy-001",
+        "beckn:mode": "DELIVERY",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:payment": {
+        "@type": "beckn:Payment",
+        "beckn:id": "payment-energy-001",
+        "beckn:paymentStatus": "PENDING",
+        "beckn:beneficiary": "BPP",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:orderStatus": "CREATED",
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
       }
     }
   }
 }
-

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_select.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_select.json
@@ -17,23 +17,6 @@
       "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
       "@type": "beckn:Order",
       "beckn:id": "order-energy-001",
-      "beckn:items": [
-        {
-          "beckn:id": "energy-resource-solar-001",
-          "quantity": {
-            "count": 10.0,
-            "unit": "kWh"
-          }
-        }
-      ],
-      "beckn:offers": [
-        {
-          "beckn:id": "offer-energy-001"
-        }
-      ],
-      "beckn:provider": {
-        "beckn:id": "provider-solar-farm-001"
-      },
       "beckn:orderValue": {
         "@type": "schema:PriceSpecification",
         "schema:price": 4.0,
@@ -52,8 +35,39 @@
             "description": "Wheeling Charges"
           }
         ]
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "line-1",
+          "beckn:orderedItem": "energy-resource-solar-001",
+          "beckn:quantity": {
+            "unitQuantity": 10.0,
+            "unitText": "kWh"
+          }
+        }
+      ],
+      "beckn:acceptedOffers": [
+        {
+          "beckn:id": "offer-energy-001",
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+          "@type": "beckn:Offer",
+          "beckn:descriptor": {
+            "@type": "beckn:Descriptor",
+            "schema:name": "Offer Descriptor"
+          },
+          "beckn:provider": "provider-placeholder",
+          "beckn:items": [
+            "dummy-item-1"
+          ]
+        }
+      ],
+      "beckn:seller": "provider-solar-farm-001",
+      "beckn:orderStatus": "CREATED",
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
       }
     }
   }
 }
-

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_status.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_status.json
@@ -17,99 +17,6 @@
       "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
       "@type": "beckn:Order",
       "beckn:id": "order-energy-001",
-      "beckn:items": [
-        {
-          "beckn:id": "energy-resource-solar-001",
-          "quantity": {
-            "count": 10.0,
-            "unit": "kWh"
-          }
-        }
-      ],
-      "beckn:offers": [
-        {
-          "beckn:id": "offer-energy-001"
-        }
-      ],
-      "beckn:provider": {
-        "beckn:id": "provider-solar-farm-001"
-      },
-      "beckn:fulfillments": [
-        {
-          "@type": "beckn:Fulfillment",
-          "beckn:id": "fulfillment-energy-001",
-          "beckn:type": "ENERGY_DELIVERY",
-          "beckn:state": {
-            "@type": "beckn:State",
-            "beckn:descriptor": {
-              "@type": "beckn:Descriptor",
-              "schema:name": "IN_PROGRESS"
-            }
-          },
-          "beckn:attributes": {
-            "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeDelivery/v0.2/context.jsonld",
-            "@type": "EnergyTradeDelivery",
-            "deliveryStatus": "IN_PROGRESS",
-            "deliveryMode": "GRID_INJECTION",
-            "deliveredQuantity": 9.8,
-            "deliveryStartTime": "2024-10-04T10:00:00Z",
-            "deliveryEndTime": null,
-            "meterReadings": [
-              {
-                "timestamp": "2024-10-04T10:00:00Z",
-                "sourceReading": 1000.0,
-                "targetReading": 990.0,
-                "energyFlow": 10.0
-              },
-              {
-                "timestamp": "2024-10-04T12:00:00Z",
-                "sourceReading": 1000.5,
-                "targetReading": 990.3,
-                "energyFlow": 10.2
-              },
-              {
-                "timestamp": "2024-10-04T14:00:00Z",
-                "sourceReading": 1001.0,
-                "targetReading": 990.8,
-                "energyFlow": 10.2
-              }
-            ],
-            "telemetry": [
-              {
-                "eventTime": "2024-10-04T12:00:00Z",
-                "metrics": [
-                  {
-                    "name": "ENERGY",
-                    "value": 5.8,
-                    "unitCode": "KWH"
-                  },
-                  {
-                    "name": "POWER",
-                    "value": 2.5,
-                    "unitCode": "KW"
-                  },
-                  {
-                    "name": "VOLTAGE",
-                    "value": 240.0,
-                    "unitCode": "VLT"
-                  }
-                ]
-              }
-            ],
-            "settlementCycleId": "settle-2024-10-04-001",
-            "lastUpdated": "2024-10-04T15:30:00Z"
-          }
-        }
-      ],
-      "beckn:payments": [
-        {
-          "@type": "beckn:Payment",
-          "beckn:id": "payment-energy-001",
-          "beckn:type": "ON-FULFILLMENT",
-          "beckn:status": "NOT-PAID",
-          "beckn:collected_by": "BPP"
-        }
-      ],
       "beckn:orderAttributes": {
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeContract/v0.2/context.jsonld",
         "@type": "EnergyTradeContract",
@@ -138,8 +45,106 @@
           }
         ],
         "lastUpdated": "2024-10-04T15:30:00Z"
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "line-1",
+          "beckn:orderedItem": "energy-resource-solar-001",
+          "beckn:quantity": {
+            "unitQuantity": 10.0,
+            "unitText": "kWh"
+          }
+        }
+      ],
+      "beckn:acceptedOffers": [
+        {
+          "beckn:id": "offer-energy-001",
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+          "@type": "beckn:Offer",
+          "beckn:descriptor": {
+            "@type": "beckn:Descriptor",
+            "schema:name": "Offer Descriptor"
+          },
+          "beckn:provider": "provider-placeholder",
+          "beckn:items": [
+            "dummy-item-1"
+          ]
+        }
+      ],
+      "beckn:seller": "provider-solar-farm-001",
+      "beckn:fulfillment": {
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-energy-001",
+        "beckn:fulfillmentStatus": "IN_PROGRESS",
+        "beckn:mode": "DELIVERY",
+        "beckn:deliveryAttributes": {
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeDelivery/v0.2/context.jsonld",
+          "@type": "EnergyTradeDelivery",
+          "deliveryStatus": "IN_PROGRESS",
+          "deliveryMode": "GRID_INJECTION",
+          "deliveredQuantity": 9.8,
+          "deliveryStartTime": "2024-10-04T10:00:00Z",
+          "deliveryEndTime": null,
+          "meterReadings": [
+            {
+              "timestamp": "2024-10-04T10:00:00Z",
+              "sourceReading": 1000.0,
+              "targetReading": 990.0,
+              "energyFlow": 10.0
+            },
+            {
+              "timestamp": "2024-10-04T12:00:00Z",
+              "sourceReading": 1000.5,
+              "targetReading": 990.3,
+              "energyFlow": 10.2
+            },
+            {
+              "timestamp": "2024-10-04T14:00:00Z",
+              "sourceReading": 1001.0,
+              "targetReading": 990.8,
+              "energyFlow": 10.2
+            }
+          ],
+          "telemetry": [
+            {
+              "eventTime": "2024-10-04T12:00:00Z",
+              "metrics": [
+                {
+                  "name": "ENERGY",
+                  "value": 5.8,
+                  "unitCode": "KWH"
+                },
+                {
+                  "name": "POWER",
+                  "value": 2.5,
+                  "unitCode": "KW"
+                },
+                {
+                  "name": "VOLTAGE",
+                  "value": 240.0,
+                  "unitCode": "VLT"
+                }
+              ]
+            }
+          ],
+          "settlementCycleId": "settle-2024-10-04-001",
+          "lastUpdated": "2024-10-04T15:30:00Z"
+        },
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:payment": {
+        "@type": "beckn:Payment",
+        "beckn:id": "payment-energy-001",
+        "beckn:paymentStatus": "PENDING",
+        "beckn:beneficiary": "BPP",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:orderStatus": "CREATED",
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
       }
     }
   }
 }
-

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_update.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/bpp/on_update.json
@@ -17,36 +17,42 @@
       "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
       "@type": "beckn:Order",
       "beckn:id": "order-energy-001",
-      "beckn:items": [
-        {
-          "beckn:id": "energy-resource-solar-001",
-          "quantity": {
-            "count": 10.0,
-            "unit": "kWh"
-          }
-        }
-      ],
-      "beckn:fulfillments": [
-        {
-          "@type": "beckn:Fulfillment",
-          "beckn:id": "fulfillment-energy-001",
-          "beckn:type": "ENERGY_DELIVERY",
-          "beckn:attributes": {
-            "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeDelivery/v0.2/context.jsonld",
-            "@type": "EnergyTradeDelivery",
-            "deliveryStatus": "IN_PROGRESS",
-            "deliveredQuantity": 9.9,
-            "lastUpdated": "2024-10-04T16:00:00Z"
-          }
-        }
-      ],
       "beckn:orderAttributes": {
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeContract/v0.2/context.jsonld",
         "@type": "EnergyTradeContract",
         "contractStatus": "ACTIVE",
         "lastUpdated": "2024-10-04T16:00:00Z"
-      }
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "line-1",
+          "beckn:orderedItem": "energy-resource-solar-001",
+          "beckn:quantity": {
+            "unitQuantity": 10.0,
+            "unitText": "kWh"
+          }
+        }
+      ],
+      "beckn:fulfillment": {
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-energy-001",
+        "beckn:mode": "DELIVERY",
+        "beckn:deliveryAttributes": {
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeDelivery/v0.2/context.jsonld",
+          "@type": "EnergyTradeDelivery",
+          "deliveryStatus": "IN_PROGRESS",
+          "deliveredQuantity": 9.9,
+          "lastUpdated": "2024-10-04T16:00:00Z"
+        },
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:orderStatus": "CREATED",
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
+      },
+      "beckn:seller": "seller-placeholder"
     }
   }
 }
-

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/utility-bpp/on_confirm.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/utility-bpp/on_confirm.json
@@ -17,46 +17,6 @@
       "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
       "@type": "beckn:Order",
       "beckn:id": "order-cascaded-utility-001",
-      "beckn:items": [
-        {
-          "beckn:id": "energy-resource-solar-001",
-          "quantity": {
-            "count": 10.0,
-            "unit": "kWh"
-          }
-        }
-      ],
-      "beckn:offers": [
-        {
-          "beckn:id": "offer-energy-001"
-        }
-      ],
-      "beckn:provider": {
-        "beckn:id": "provider-solar-farm-001"
-      },
-      "beckn:fulfillments": [
-        {
-          "@type": "beckn:Fulfillment",
-          "beckn:id": "fulfillment-energy-001",
-          "beckn:type": "ENERGY_DELIVERY",
-          "beckn:state": {
-            "@type": "beckn:State",
-            "beckn:descriptor": {
-              "@type": "beckn:Descriptor",
-              "schema:name": "PENDING"
-            }
-          }
-        }
-      ],
-      "beckn:payments": [
-        {
-          "@type": "beckn:Payment",
-          "beckn:id": "payment-energy-001",
-          "beckn:type": "ON-FULFILLMENT",
-          "beckn:status": "NOT-PAID",
-          "beckn:collected_by": "BPP"
-        }
-      ],
       "beckn:orderAttributes": {
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeContract/v0.2/context.jsonld",
         "@type": "EnergyTradeContract",
@@ -96,8 +56,53 @@
             "unit": "kWh"
           }
         }
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "line-1",
+          "beckn:orderedItem": "energy-resource-solar-001",
+          "beckn:quantity": {
+            "unitQuantity": 10.0,
+            "unitText": "kWh"
+          }
+        }
+      ],
+      "beckn:acceptedOffers": [
+        {
+          "beckn:id": "offer-energy-001",
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+          "@type": "beckn:Offer",
+          "beckn:descriptor": {
+            "@type": "beckn:Descriptor",
+            "schema:name": "Offer Descriptor"
+          },
+          "beckn:provider": "provider-placeholder",
+          "beckn:items": [
+            "dummy-item-1"
+          ]
+        }
+      ],
+      "beckn:seller": "provider-solar-farm-001",
+      "beckn:fulfillment": {
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-energy-001",
+        "beckn:fulfillmentStatus": "PENDING",
+        "beckn:mode": "DELIVERY",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:payment": {
+        "@type": "beckn:Payment",
+        "beckn:id": "payment-energy-001",
+        "beckn:paymentStatus": "PENDING",
+        "beckn:beneficiary": "BPP",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:orderStatus": "CREATED",
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
       }
     }
   }
 }
-

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/utility-bpp/on_init.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/utility-bpp/on_init.json
@@ -17,73 +17,6 @@
       "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
       "@type": "beckn:Order",
       "beckn:id": "order-cascaded-utility-001",
-      "beckn:items": [
-        {
-          "beckn:id": "energy-resource-solar-001",
-          "quantity": {
-            "count": 10.0,
-            "unit": "kWh"
-          }
-        }
-      ],
-      "beckn:offers": [
-        {
-          "beckn:id": "offer-energy-001"
-        }
-      ],
-      "beckn:provider": {
-        "beckn:id": "provider-solar-farm-001"
-      },
-      "beckn:fulfillments": [
-        {
-          "@type": "beckn:Fulfillment",
-          "beckn:id": "fulfillment-energy-001",
-          "beckn:type": "ENERGY_DELIVERY",
-          "beckn:stops": [
-            {
-              "@type": "beckn:Stop",
-              "beckn:id": "stop-start-001",
-              "beckn:type": "START",
-              "beckn:location": {
-                "@type": "beckn:Location",
-                "beckn:address": "100200300"
-              },
-              "beckn:time": {
-                "@type": "beckn:Time",
-                "beckn:range": {
-                  "start": "2024-10-04T10:00:00Z",
-                  "end": "2024-10-04T18:00:00Z"
-                }
-              }
-            },
-            {
-              "@type": "beckn:Stop",
-              "beckn:id": "stop-end-001",
-              "beckn:type": "END",
-              "beckn:location": {
-                "@type": "beckn:Location",
-                "beckn:address": "98765456"
-              },
-              "beckn:time": {
-                "@type": "beckn:Time",
-                "beckn:range": {
-                  "start": "2024-10-04T10:00:00Z",
-                  "end": "2024-10-04T18:00:00Z"
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "beckn:payments": [
-        {
-          "@type": "beckn:Payment",
-          "beckn:id": "payment-energy-001",
-          "beckn:type": "ON-FULFILLMENT",
-          "beckn:status": "NOT-PAID",
-          "beckn:collected_by": "BPP"
-        }
-      ],
       "beckn:orderValue": {
         "@type": "schema:PriceSpecification",
         "schema:price": 2.5,
@@ -120,13 +53,51 @@
           }
         }
       },
-      "beckn:billing": {
-        "@type": "beckn:Billing",
-        "beckn:name": "Energy Consumer",
-        "beckn:email": "consumer@example.com",
-        "beckn:phone": "+1-555-0100"
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "line-1",
+          "beckn:orderedItem": "energy-resource-solar-001",
+          "beckn:quantity": {
+            "unitQuantity": 10.0,
+            "unitText": "kWh"
+          }
+        }
+      ],
+      "beckn:acceptedOffers": [
+        {
+          "beckn:id": "offer-energy-001",
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+          "@type": "beckn:Offer",
+          "beckn:descriptor": {
+            "@type": "beckn:Descriptor",
+            "schema:name": "Offer Descriptor"
+          },
+          "beckn:provider": "provider-placeholder",
+          "beckn:items": [
+            "dummy-item-1"
+          ]
+        }
+      ],
+      "beckn:seller": "provider-solar-farm-001",
+      "beckn:fulfillment": {
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-energy-001",
+        "beckn:mode": "DELIVERY",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:payment": {
+        "@type": "beckn:Payment",
+        "beckn:id": "payment-energy-001",
+        "beckn:paymentStatus": "PENDING",
+        "beckn:beneficiary": "BPP",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:orderStatus": "CREATED",
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
       }
     }
   }
 }
-

--- a/src/webhook/jsons/beckn.one:deg:p2p-trading/response/utility-bpp/on_update.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-trading/response/utility-bpp/on_update.json
@@ -17,21 +17,6 @@
       "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
       "@type": "beckn:Order",
       "beckn:id": "order-cascaded-utility-001",
-      "beckn:fulfillments": [
-        {
-          "@type": "beckn:Fulfillment",
-          "beckn:id": "fulfillment-energy-001",
-          "beckn:type": "ENERGY_DELIVERY",
-          "beckn:attributes": {
-            "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeDelivery/v0.2/context.jsonld",
-            "@type": "EnergyTradeDelivery",
-            "deliveryStatus": "COMPLETED",
-            "deliveredQuantity": 10.0,
-            "deliveryEndTime": "2024-10-04T18:00:00Z",
-            "lastUpdated": "2024-10-04T18:30:00Z"
-          }
-        }
-      ],
       "beckn:orderAttributes": {
         "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeContract/v0.2/context.jsonld",
         "@type": "EnergyTradeContract",
@@ -49,8 +34,38 @@
           }
         ],
         "lastUpdated": "2024-10-04T18:30:00Z"
-      }
+      },
+      "beckn:fulfillment": {
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-energy-001",
+        "beckn:mode": "DELIVERY",
+        "beckn:deliveryAttributes": {
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyTradeDelivery/v0.2/context.jsonld",
+          "@type": "EnergyTradeDelivery",
+          "deliveryStatus": "COMPLETED",
+          "deliveredQuantity": 10.0,
+          "deliveryEndTime": "2024-10-04T18:00:00Z",
+          "lastUpdated": "2024-10-04T18:30:00Z"
+        },
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"
+      },
+      "beckn:orderStatus": "CREATED",
+      "beckn:buyer": {
+        "beckn:id": "buyer-placeholder",
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer"
+      },
+      "beckn:seller": "seller-placeholder",
+      "beckn:orderItems": [
+        {
+          "beckn:lineId": "dummy-line-1",
+          "beckn:orderedItem": "dummy-item-1",
+          "beckn:quantity": {
+            "unitQuantity": 1,
+            "unitText": "unit"
+          }
+        }
+      ]
     }
   }
 }
-


### PR DESCRIPTION
Confirmed that p2p payloads are passing schema validation in the devkit.

This closes #6 partially.