### PR TITLE
Add peer to peer enrollment jsons

### DIFF
--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_cancel.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_cancel.json
@@ -1,0 +1,50 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_cancel",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-11-25T09:00:05Z",
+    "message_id": "msg-on-cancel-enrollment-001",
+    "transaction_id": "txn-cancel-enrollment-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+      "@type": "beckn:Order",
+      "beckn:id": "order-onboard-consumer-001",
+      "beckn:orderStatus": "CANCELLED",
+      "beckn:seller": "vpp-program-flex-001",
+      "beckn:buyer": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer",
+        "beckn:id": "did:example:user-12345"
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:orderedItem": "program-flex-demand-response-001"
+        }
+      ],
+      "beckn:fulfillment": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-onboard-001",
+        "beckn:mode": "DIGITAL",
+        "beckn:fulfillmentStatus": "CANCELLED"
+      },
+      "beckn:orderAttributes": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyEnrollment/v0.2/context.jsonld",
+        "@type": "EnergyEnrollment",
+        "enrollmentId": "enrollment-consumer-001",
+        "status": "CANCELLED",
+        "cancelledAt": "2024-11-25T09:00:05Z",
+        "cancellationReason": "User requested unenrollment from the program"
+      }
+    }
+  }
+}
+

--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_confirm.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_confirm.json
@@ -1,0 +1,68 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_confirm",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-10-15T10:35:05Z",
+    "message_id": "msg-on-confirm-consumer-001",
+    "transaction_id": "txn-onboard-consumer-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+      "@type": "beckn:Order",
+      "beckn:id": "order-onboard-consumer-001",
+      "beckn:orderStatus": "CONFIRMED",
+      "beckn:orderNumber": "ENR-2024-001234",
+      "beckn:seller": "vpp-program-flex-001",
+      "beckn:buyer": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer",
+        "beckn:id": "did:example:user-12345"
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:orderedItem": "program-flex-demand-response-001"
+        }
+      ],
+      "beckn:fulfillment": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-onboard-001",
+        "beckn:mode": "DIGITAL",
+        "beckn:fulfillmentStatus": "CONFIRMED",
+        "beckn:deliveryAttributes": {
+          "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyEnrollment/v0.2/context.jsonld",
+          "@type": "EnergyEnrollment",
+          "credential": {
+            "credentialId": "vc:enrollment:consumer-001",
+            "type": "ProgramEnrollmentCredential",
+            "format": "VC-JWT",
+            "credentialUrl": "https://vpp-program-owner.example.com/credentials/vc:enrollment:consumer-001",
+            "verificationUrl": "https://vpp-program-owner.example.com/verify/vc:enrollment:consumer-001",
+            "issuedAt": "2024-10-15T10:35:05Z",
+            "credentialData": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUHJvZ3JhbUVucm9sbG1lbnRDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmV4YW1wbGU6dXNlci0xMjM0NSIsImVucm9sbG1lbnRJZCI6ImVucm9sbG1lbnQtY29uc3VtZXItMDAxIiwicHJvZ3JhbUlkIjoicHJvZ3JhbS1mbGV4LWRlbWFuZC1yZXNwb25zZS0wMDEiLCJtZXRlcnMiOlsidW1pZC0wMDEiXSwic3RhdHVzIjoiQUNUSVZFIiwic3RhcnREYXRlIjoiMjAyNC0xMS0wMVQwMDowMDowMFoiLCJlbmREYXRlIjoiMjAyNS0xMC0zMVQyMzo1OTo1OVoifSwiaXNzdWFuY2VEYXRlIjoiMjAyNC0xMC0xNVQxMDozNTowNVoiLCJleHBpcmF0aW9uRGF0ZSI6IjIwMjUtMTAtMzFUMjM6NTk6NTlaIn0sImlzcyI6ImRpZDpleGFtcGxlOnZwcC1wcm9ncmFtLW93bmVyIiwiaWF0IjoxNzI5MDk3NzA1fQ.signature"
+          }
+        }
+      },
+      "beckn:orderAttributes": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyEnrollment/v0.2/context.jsonld",
+        "@type": "EnergyEnrollment",
+        "enrollmentId": "enrollment-consumer-001",
+        "status": "ACTIVE",
+        "programId": "program-flex-demand-response-001",
+        "startDate": "2024-11-01T00:00:00Z",
+        "endDate": "2025-10-31T23:59:59Z",
+        "enrolledAt": "2024-10-15T10:35:05Z",
+        "loggedAt": "2024-10-15T10:35:05Z",
+        "logReference": "log-enrollment-consumer-001"
+      }
+    }
+  }
+}
+

--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_init.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_init.json
@@ -1,0 +1,95 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_init",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-10-15T10:30:05Z",
+    "message_id": "msg-on-init-consumer-001",
+    "transaction_id": "txn-onboard-consumer-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+      "@type": "beckn:Order",
+      "beckn:id": "order-onboard-consumer-001",
+      "beckn:orderStatus": "PENDING",
+      "beckn:seller": "vpp-program-flex-001",
+      "beckn:buyer": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer",
+        "beckn:id": "did:example:user-12345"
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:orderedItem": "program-flex-demand-response-001"
+        }
+      ],
+      "beckn:fulfillment": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-onboard-001",
+        "beckn:mode": "DIGITAL",
+        "beckn:fulfillmentStatus": "PENDING"
+      },
+      "beckn:orderAttributes": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyEnrollment/v0.2/context.jsonld",
+        "@type": "EnergyEnrollment",
+        "credentialVerification": {
+          "status": "VERIFIED",
+          "verifiedCredentials": [
+            {
+              "credentialId": "vc-meter-ownership-001",
+              "status": "VERIFIED",
+              "verifiedAt": "2024-10-15T10:30:05Z"
+            },
+            {
+              "credentialId": "vc-program-eligibility-001",
+              "status": "VERIFIED",
+              "verifiedAt": "2024-10-15T10:30:05Z"
+            }
+          ]
+        },
+        "conflictCheck": {
+          "hasConflict": false,
+          "checkedAt": "2024-10-15T10:30:05Z",
+          "message": "No conflicts found with existing enrollments"
+        },
+        "requiredCredentials": [
+          {
+            "type": "MeterOwnershipCredential",
+            "description": "Proof of meter ownership verified through utility OTP verification",
+            "status": "PROVIDED"
+          },
+          {
+            "type": "ProgramEligibilityCredential",
+            "description": "Proof of program eligibility based on meter type and location",
+            "status": "PROVIDED"
+          }
+        ],
+        "requiredConsents": [
+          {
+            "type": "DATA_COLLECTION",
+            "description": "Consent to collect and share meter data for program participation",
+            "required": true
+          },
+          {
+            "type": "DER_CONTROL",
+            "description": "Consent to control DER devices for demand response (if applicable)",
+            "required": false
+          },
+          {
+            "type": "CROSS_UTILITY_SHARING",
+            "description": "Consent to share data across utilities (if applicable)",
+            "required": false
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_rating.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_rating.json
@@ -1,0 +1,20 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_rating",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-11-01T12:00:05Z",
+    "message_id": "msg-on-rating-enrollment-001",
+    "transaction_id": "txn-rating-enrollment-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "feedback_ack": true,
+    "rating_ack": true
+  }
+}
+

--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_select.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_select.json
@@ -1,0 +1,82 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_select",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-10-15T10:25:05Z",
+    "message_id": "msg-on-select-consumer-001",
+    "transaction_id": "txn-onboard-consumer-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+      "@type": "beckn:Order",
+      "beckn:id": "order-onboard-consumer-001",
+      "beckn:orderStatus": "CREATED",
+      "beckn:seller": "vpp-program-flex-001",
+      "beckn:buyer": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer",
+        "beckn:id": "did:example:user-12345"
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:orderedItem": "program-flex-demand-response-001",
+          "beckn:acceptedOffer": {
+            "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+            "@type": "beckn:Offer",
+            "beckn:id": "offer-flex-program-001",
+            "beckn:descriptor": {
+              "@type": "beckn:Descriptor",
+              "schema:name": "Flex Demand Response Program",
+              "schema:description": "Participate in demand response events for grid stability"
+            },
+            "beckn:provider": "vpp-program-flex-001",
+            "beckn:items": ["program-flex-demand-response-001"]
+          }
+        }
+      ],
+      "beckn:fulfillment": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-onboard-001",
+        "beckn:mode": "DIGITAL",
+        "beckn:fulfillmentStatus": "CREATED"
+      },
+      "beckn:orderAttributes": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyEnrollment/v0.2/context.jsonld",
+        "@type": "EnergyEnrollment",
+        "requiredCredentials": [
+          {
+            "type": "MeterOwnershipCredential",
+            "description": "Proof of meter ownership verified through utility OTP verification",
+            "status": "REQUIRED"
+          },
+          {
+            "type": "ProgramEligibilityCredential",
+            "description": "Proof of program eligibility based on meter type and location",
+            "status": "REQUIRED"
+          }
+        ],
+        "requiredConsents": [
+          {
+            "type": "DATA_COLLECTION",
+            "description": "Consent to collect and share meter data for program participation",
+            "required": true
+          },
+          {
+            "type": "DER_CONTROL",
+            "description": "Consent to control DER devices for demand response (if applicable)",
+            "required": false
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_status.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_status.json
@@ -1,0 +1,61 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_status",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-11-01T12:00:05Z",
+    "message_id": "msg-on-status-enrollment-001",
+    "transaction_id": "txn-status-enrollment-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+      "@type": "beckn:Order",
+      "beckn:id": "order-onboard-consumer-001",
+      "beckn:orderStatus": "CONFIRMED",
+      "beckn:orderNumber": "ENR-2024-001234",
+      "beckn:seller": "vpp-program-flex-001",
+      "beckn:buyer": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer",
+        "beckn:id": "did:example:user-12345"
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:orderedItem": "program-flex-demand-response-001"
+        }
+      ],
+      "beckn:fulfillment": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-onboard-001",
+        "beckn:mode": "DIGITAL",
+        "beckn:fulfillmentStatus": "CONFIRMED"
+      },
+      "beckn:orderAttributes": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyEnrollment/v0.2/context.jsonld",
+        "@type": "EnergyEnrollment",
+        "enrollmentId": "enrollment-consumer-001",
+        "status": "ACTIVE",
+        "programId": "program-flex-demand-response-001",
+        "startDate": "2024-11-01T00:00:00Z",
+        "endDate": "2025-10-31T23:59:59Z",
+        "enrolledAt": "2024-10-15T10:35:05Z",
+        "meters": [
+          {
+            "meterId": "der://meter/umid-001",
+            "meterNumber": "UMID-001",
+            "connectionType": "RESIDENTIAL",
+            "sanctionedLoad": 5.0
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_support.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_support.json
@@ -1,0 +1,24 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_support",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-11-01T12:00:05Z",
+    "message_id": "msg-on-support-enrollment-001",
+    "transaction_id": "txn-support-enrollment-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "support": {
+      "ref_id": "order-onboard-consumer-001",
+      "callback_phone": "+1-800-ENERGY-1",
+      "email": "support@vpp-program-owner.example.com",
+      "url": "https://vpp-program-owner.example.com/support"
+    }
+  }
+}
+

--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_track.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_track.json
@@ -1,0 +1,23 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_track",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-11-01T12:00:05Z",
+    "message_id": "msg-on-track-enrollment-001",
+    "transaction_id": "txn-track-enrollment-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "tracking": {
+      "id": "tracking-enrollment-001",
+      "url": "https://vpp-program-owner.example.com/track/enrollment-consumer-001",
+      "status": "active"
+    }
+  }
+}
+

--- a/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_update.json
+++ b/src/webhook/jsons/beckn.one:deg:p2p-enrollment/response/on_update.json
@@ -1,0 +1,57 @@
+{
+  "context": {
+    "version": "2.0.0",
+    "action": "on_update",
+    "domain": "beckn.one:deg:p2p-enrollment:2.0.0",
+    "timestamp": "2024-11-20T14:30:05Z",
+    "message_id": "msg-on-update-consent-revoke-001",
+    "transaction_id": "txn-revoke-consent-001",
+    "bap_id": "utility-portal.example.com",
+    "bap_uri": "https://utility-portal.example.com/beckn",
+    "bpp_id": "vpp-program-owner.example.com",
+    "bpp_uri": "https://vpp-program-owner.example.com/beckn",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+      "@type": "beckn:Order",
+      "beckn:id": "order-onboard-consumer-001",
+      "beckn:orderStatus": "CONFIRMED",
+      "beckn:seller": "vpp-program-flex-001",
+      "beckn:buyer": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Buyer",
+        "beckn:id": "did:example:user-12345"
+      },
+      "beckn:orderItems": [
+        {
+          "beckn:orderedItem": "program-flex-demand-response-001"
+        }
+      ],
+      "beckn:fulfillment": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/core/v2/context.jsonld",
+        "@type": "beckn:Fulfillment",
+        "beckn:id": "fulfillment-onboard-001",
+        "beckn:mode": "DIGITAL",
+        "beckn:fulfillmentStatus": "CONFIRMED"
+      },
+      "beckn:orderAttributes": {
+        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/p2p-trading/schema/EnergyEnrollment/v0.2/context.jsonld",
+        "@type": "EnergyEnrollment",
+        "enrollmentId": "enrollment-consumer-001",
+        "status": "ACTIVE",
+        "updateType": "CONSENT_REVOCATION",
+        "consentRevocation": {
+          "consentCredentialId": "https://vpp-program-owner.example.com/credentials/vc:consent:consumer-001",
+          "status": "REVOKED",
+          "revokedAt": "2024-11-20T14:30:05Z",
+          "statusListUrl": "https://vpp-program-owner.example.com/status/consent-list",
+          "statusListIndex": "94567",
+          "message": "Consent has been revoked and added to revocation status list. Future verifications will fail."
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
- Now the sandbox returns the `on_xxx` responses for `beckn.one:deg:p2p-enrollment:2.0.0` domain
- These match the example jsons currently residing at https://github.com/Beckn-One/DEG/tree/p2p-trading/examples/enrollment/v2

