### PR TITLE
feat(webhook): env-var substitution in response fixtures

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,6 +19,23 @@ export const resolveDomain = (context: any): string => {
   return context.domain || context.network_id || context.networkId;
 };
 
+/**
+ * Replaces {{VAR}} / {{VAR:-default}} placeholders in a fixture with the value
+ * of environment variable VAR, falling back to the inline default (or leaving
+ * the placeholder untouched if neither is set). Lets a mounted response fixture
+ * be re-pointed via env without editing the file, e.g.:
+ *   "ledgerUri": "{{SELLER_LEDGER_URI:-http://seller-discom-ledger.example.com:9000}}"
+ */
+const substituteEnvVars = (contents: string): string =>
+  contents.replace(
+    /\{\{(\w+)(?::-([^}]*))?\}\}/g,
+    (match, key: string, fallback?: string) => {
+      const value = process.env[key];
+      if (value !== undefined && value !== "") return value;
+      return fallback !== undefined ? fallback : match;
+    }
+  );
+
 export const readDomainResponse = async (
   domain: string,
   action: string,
@@ -38,7 +55,7 @@ export const readDomainResponse = async (
 
     try {
       const fileContents = readFileSync(personaPath, "utf-8");
-      const parsed = JSON.parse(fileContents);
+      const parsed = JSON.parse(substituteEnvVars(fileContents));
       return parsed;
     } catch (error: any) {
       if (error?.code !== "ENOENT") {


### PR DESCRIPTION
## What
`readDomainResponse` now expands `{{VAR}}` / `{{VAR:-default}}` placeholders in a response fixture against `process.env` before `JSON.parse`.

- A mounted fixture can be re-pointed via an env var without editing the file, e.g. `"ledgerUri": "{{SELLER_LEDGER_URI:-http://seller-discom-ledger.example.com:9000}}"`.
- `{{VAR:-default}}` falls back to the inline default when `VAR` is unset/empty.
- `{{VAR}}` with no default and no env value is left **untouched** — back-compatible: fixtures that don't use the syntax are unaffected.

## Why
Lets a devkit flip a fixture value (e.g. which discom ledger an `on_confirm` cascades to) per-deployment via compose env, instead of hardcoding it in the checked-in fixture. First consumer: DEG p2p-wave2 (`SELLER_LEDGER_ID` / `SELLER_LEDGER_URI`).

## Scope
Applied on the persona-specific read path in `readDomainResponse`. No new dependencies; pure string transform.